### PR TITLE
use panda's API auth action in the APIHMAC auth action

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.0"
+version in ThisBuild := "1.2.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.0-SNAPSHOT"
+version in ThisBuild := "1.2.0"


### PR DESCRIPTION
previously both the API and non api hmac auth actions used panda's auth action. This meant that api calls were redirection to google rather than 401 / 419 ing