### PR TITLE
return an `AuthenticatedRequest` where the user is a `Principal` type

### DIFF
--- a/src/main/scala/com/gu/pandahmac/HmacAuthActions.scala
+++ b/src/main/scala/com/gu/pandahmac/HmacAuthActions.scala
@@ -1,21 +1,23 @@
 package com.gu.pandahmac
 
-import com.amazonaws.handlers.RequestHandler
-import com.gu.hmac.HMACHeaders
-
 import java.net.URI
+
+import com.gu.hmac.HMACHeaders
+import com.gu.pandomainauth.action.{AuthActions, UserRequest}
+import com.gu.pandomainauth.model.User
+import play.api.mvc.Results._
+import play.api.mvc.Security.AuthenticatedRequest
+import play.api.mvc._
 
 import scala.concurrent.Future
 
-import play.api.http._
-import play.api.mvc._
-import play.api.mvc.Results._
-import play.api.libs.concurrent.Execution.Implicits._
-import play.api.mvc.Security.AuthenticatedRequest
+sealed trait Principal { def name: String }
 
-import com.gu.pandomainauth.model.{AuthenticatedUser, User}
-import com.gu.pandomainauth.action.{AuthActions, UserRequest}
+case class PandaUser(user: User) extends Principal {
+  def name: String = s"${user.firstName} ${user.lastName}"
+}
 
+case class HMACAuthenticatedService(name: String) extends Principal
 
 object HMACHeaderNames {
   val hmacKey = "X-Gu-Tools-HMAC-Token"
@@ -24,19 +26,17 @@ object HMACHeaderNames {
   val serviceNameKey = "X-Gu-Tools-Service-Name"
 }
 
-
 trait HMACAuthActions extends AuthActions with HMACHeaders {
   private def authByKeyOrPanda[A](request: Request[A], block: RequestHandler[A], useApiAuth: Boolean): Future[Result] = {
     val oHmac: Option[String] = request.headers.get(HMACHeaderNames.hmacKey)
     val oDate: Option[String] = request.headers.get(HMACHeaderNames.dateKey)
-    val oServiceName: Option[String] = request.headers.get(HMACHeaderNames.serviceNameKey)
+    val oServiceName: String = request.headers.get(HMACHeaderNames.serviceNameKey).getOrElse("hmac-authed-service")
     val uri = new URI(request.uri)
 
     (oHmac, oDate) match {
       case (Some(hmac), Some(date)) => {
         if (validateHMACHeaders(date, hmac, uri)) {
-          val user = User(oServiceName.getOrElse("hmac-authed-service"), "", "", None)
-          block(new UserRequest(user, request))
+          block(new AuthenticatedRequest(HMACAuthenticatedService(oServiceName), request))
         } else {
           Future.successful(Unauthorized)
         }
@@ -50,12 +50,12 @@ trait HMACAuthActions extends AuthActions with HMACHeaders {
 
   def authByPanda[A](request: Request[A], block: RequestHandler[A]): Future[Result] =
     AuthAction.invokeBlock(request, (request: UserRequest[A]) => {
-      block(new UserRequest(request.user, request))
+      block(new AuthenticatedRequest(PandaUser(request.user), request))
     })
 
   def apiAuthByPanda[A](request: Request[A], block: RequestHandler[A]): Future[Result] =
     APIAuthAction.invokeBlock(request, (request: UserRequest[A]) => {
-      block(new UserRequest(request.user, request))
+      block(new AuthenticatedRequest(PandaUser(request.user), request))
     })
 
   object HMACAuthAction extends ActionBuilder[UserRequest] {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.0"
+version in ThisBuild := "1.3.0"


### PR DESCRIPTION
Currently in MAM's auditing, we save the user's email property to dynamo. HMAC authed users do not have an email (its set to `""`) which dynamo isn't happy about saving.

Return a `Principal` type which can be pattern matched on rather than matching empty string on email.