### PR TITLE
Upgrade to pan-domain-auth 1.0.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ sbt-output.txt
 node_modules/
 public/build
 application.local.conf
+.bsp

--- a/build.sbt
+++ b/build.sbt
@@ -4,16 +4,15 @@ import sbt.url
 name := "panda-hmac"
 organization := "com.gu"
 
-val scala211ver = "2.11.8"
-val scala212ver = "2.12.2"
-val scala213ver = "2.13.7"
+val scala212ver = "2.12.16"
+val scala213ver = "2.13.8"
 
 ThisBuild / description := "Wraps the panda play library to allow either panda cookie or HMAC shared secret auth"
 
 scalacOptions ++= Seq("-feature", "-deprecation")
 
 lazy val root = (project in file("."))
-  .aggregate(play28project, play26project)
+  .aggregate(play28project, play27project)
   .settings(
     // crossScalaVersions must be set to Nil on the aggregating project
     crossScalaVersions := Nil,
@@ -36,7 +35,7 @@ lazy val `play28project` = (project in file("play")).settings(
     "com.typesafe.play" %% "play" % "2.8.11" % "provided",
     "com.typesafe.play" %% "play-ws" % "2.8.11" % "provided",
     "com.gu" %% "hmac-headers" % "1.2.0",
-    "com.gu" %% "pan-domain-auth-play_2-8" % "1.0.4"
+    "com.gu" %% "pan-domain-auth-play_2-8" % "1.0.6"
   ),
   // Add sonatype repository settings
   publishTo := Some(
@@ -59,16 +58,16 @@ lazy val `play28project` = (project in file("play")).settings(
   licenses += ("Apache-2.0", url("https://github.com/guardian/tags-thrift-schema/blob/master/LICENSE")),
 )
 
-lazy val `play26project` = (project in file("play")).settings(
-  crossScalaVersions := List(scala211ver,scala212ver),
-  target := file("target/play_2-6"),
-  name := "panda-hmac-play_2-6",
+lazy val `play27project` = (project in file("play")).settings(
+  crossScalaVersions := List(scala212ver),
+  target := file("target/play_2-7"),
+  name := "panda-hmac-play_2-7",
   organization := "com.gu",
   libraryDependencies ++= Seq(
-    "com.typesafe.play" %% "play" % "2.6.0" % "provided",
-    "com.typesafe.play" %% "play-ws" % "2.6.0" % "provided",
+    "com.typesafe.play" %% "play" % "2.7.0" % "provided",
+    "com.typesafe.play" %% "play-ws" % "2.7.0" % "provided",
     "com.gu" %% "hmac-headers" % "1.2.0",
-    "com.gu" %% "pan-domain-auth-play_2-6" % "0.7.2"
+    "com.gu" %% "pan-domain-auth-play_2-7" % "1.0.6"
   ),
   // Add sonatype repository settings
   publishTo := Some(


### PR DESCRIPTION
Drop support for Scala 2.11 and Play 2.6

## What does this change?

Upgrades pan-domain-auth-play dependency to v1.0.6.
v1.0.6 is only available for Scala >= 2.12 and Play >= 2.7, so convert the Play 2.6 build to Play 2.7 and drop the Scala 2.11 build.