### PR TITLE
Update release process using sbt-release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 import sbt.Keys.{publishMavenStyle, scmInfo}
 import sbt.url
+import ReleaseTransformations._
 
 name := "panda-hmac"
 organization := "com.gu"
@@ -11,81 +12,71 @@ ThisBuild / description := "Wraps the panda play library to allow either panda c
 
 scalacOptions ++= Seq("-feature", "-deprecation")
 
-lazy val root = (project in file("."))
-  .aggregate(play28project, play27project)
-  .settings(
-    // crossScalaVersions must be set to Nil on the aggregating project
-    crossScalaVersions := Nil,
-    publish / skip := false,
-    // Add sonatype repository settings
-    publishTo := Some(
-      if (isSnapshot.value)
-        Opts.resolver.sonatypeSnapshots
-      else
-        Opts.resolver.sonatypeStaging
-    )
-  )
-
-lazy val `play28project` = (project in file("play")).settings(
-  crossScalaVersions := List(scala212ver,scala213ver),
-  target := file("target/play_2-8"),
-  name := "panda-hmac-play_2-8",
+lazy val commonSettings = Seq(
   organization := "com.gu",
+  scalaVersion := scala212ver,
+  // Add sonatype repository settings
+  publishTo := sonatypePublishToBundle.value,
+  homepage := Some(url("https://github.com/guardian/panda-hmac")),
+  scmInfo := Some(ScmInfo(
+    url("https://github.com/guardian/panda-hmac"),
+    "git@github.com:guardian/panda-hmac.git")
+  ),
+  publishMavenStyle := true,
+  developers := List(
+    Developer(
+      id    = "GuardianEdTools",
+      name  = "Guardian Editorial Tools",
+      email = "digitalcms.dev@theguardian.com",
+      url   = url("https://www.theguardian.com")
+    )
+  ),
+  licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html")),
+  releaseCrossBuild := true, // true if you cross-build the project for multiple Scala versions
+  releaseProcess := Seq[ReleaseStep](
+    checkSnapshotDependencies,
+    inquireVersions,
+    runClean,
+    runTest,
+    setReleaseVersion,
+    commitReleaseVersion,
+    tagRelease,
+    // For non cross-build projects, use releaseStepCommand("publishSigned")
+    releaseStepCommandAndRemaining("+publishSigned"),
+    releaseStepCommand("sonatypeBundleRelease"),
+    setNextVersion,
+    commitNextVersion,
+    pushChanges
+  )
+)
+
+lazy val `play28project` = (project in file("play")).settings(commonSettings).settings(
+  name := "panda-hmac-play_2-8",
+  crossScalaVersions := List(scala212ver, scala213ver),
+  target := file("target/play_2-8"),
   libraryDependencies ++= Seq(
     "com.typesafe.play" %% "play" % "2.8.11" % "provided",
     "com.typesafe.play" %% "play-ws" % "2.8.11" % "provided",
     "com.gu" %% "hmac-headers" % "1.2.0",
     "com.gu" %% "pan-domain-auth-play_2-8" % "1.0.6"
   ),
-  // Add sonatype repository settings
-  publishTo := Some(
-    if (isSnapshot.value)
-      Opts.resolver.sonatypeSnapshots
-    else
-      Opts.resolver.sonatypeStaging
-  ),
-  homepage := Some(url("https://github.com/guardian/panda-hmac")),
-  scmInfo := Some(ScmInfo(url("https://github.com/guardian/panda-hmac"),"git@github.com:guardian/panda-hmac.git")),
-  publishMavenStyle := true,
-  developers := List(
-    Developer(
-      id    = "GuardianEdTools",
-      name  = "guardian editorial tools",
-      email = "digitalcms.dev@theguardian.com",
-      url   = url("https://www.theguardian.com")
-    )
-  ),
-  licenses += ("Apache-2.0", url("https://github.com/guardian/tags-thrift-schema/blob/master/LICENSE")),
 )
 
-lazy val `play27project` = (project in file("play")).settings(
+lazy val `play27project` = (project in file("play")).settings(commonSettings).settings(
+  name := "panda-hmac-play_2-7",
   crossScalaVersions := List(scala212ver),
   target := file("target/play_2-7"),
-  name := "panda-hmac-play_2-7",
-  organization := "com.gu",
   libraryDependencies ++= Seq(
     "com.typesafe.play" %% "play" % "2.7.0" % "provided",
     "com.typesafe.play" %% "play-ws" % "2.7.0" % "provided",
     "com.gu" %% "hmac-headers" % "1.2.0",
     "com.gu" %% "pan-domain-auth-play_2-7" % "1.0.6"
   ),
-  // Add sonatype repository settings
-  publishTo := Some(
-    if (isSnapshot.value)
-      Opts.resolver.sonatypeSnapshots
-    else
-      Opts.resolver.sonatypeStaging
-  ),
-  homepage := Some(url("https://github.com/guardian/panda-hmac")),
-  scmInfo := Some(ScmInfo(url("https://github.com/guardian/panda-hmac"),"git@github.com:guardian/panda-hmac.git")),
-  publishMavenStyle := true,
-  developers := List(
-    Developer(
-      id    = "GuardianEdTools",
-      name  = "guardian editorial tools",
-      email = "digitalcms.dev@theguardian.com",
-      url   = url("https://www.theguardian.com")
-    )
-  ),
-  licenses += ("Apache-2.0", url("https://github.com/guardian/tags-thrift-schema/blob/master/LICENSE")),
 )
+
+lazy val root = (project in file("."))
+  .aggregate(play28project, play27project)
+  .settings(
+    publishArtifact := false,
+    publish / skip := true,
+  )

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 import sbt.Keys.{publishMavenStyle, scmInfo}
 import sbt.url
 import ReleaseTransformations._
+import xerial.sbt.Sonatype._
 
 name := "panda-hmac"
 organization := "com.gu"
@@ -12,7 +13,7 @@ ThisBuild / description := "Wraps the panda play library to allow either panda c
 
 scalacOptions ++= Seq("-feature", "-deprecation")
 
-lazy val commonSettings = Seq(
+lazy val commonSettings = sonatypeSettings ++ Seq(
   organization := "com.gu",
   scalaVersion := scala212ver,
   // Add sonatype repository settings

--- a/build.sbt
+++ b/build.sbt
@@ -79,6 +79,7 @@ lazy val `play27project` = (project in file("play")).settings(commonSettings).se
 
 lazy val root = (project in file("."))
   .aggregate(play28project, play27project)
+  .settings(commonSettings)
   .settings(
     publishArtifact := false,
     publish / skip := true,

--- a/build.sbt
+++ b/build.sbt
@@ -54,6 +54,7 @@ lazy val `play28project` = (project in file("play")).settings(commonSettings).se
   name := "panda-hmac-play_2-8",
   crossScalaVersions := List(scala212ver, scala213ver),
   target := file("target/play_2-8"),
+  publishArtifact := true,
   libraryDependencies ++= Seq(
     "com.typesafe.play" %% "play" % "2.8.11" % "provided",
     "com.typesafe.play" %% "play-ws" % "2.8.11" % "provided",
@@ -66,6 +67,7 @@ lazy val `play27project` = (project in file("play")).settings(commonSettings).se
   name := "panda-hmac-play_2-7",
   crossScalaVersions := List(scala212ver),
   target := file("target/play_2-7"),
+  publishArtifact := true,
   libraryDependencies ++= Seq(
     "com.typesafe.play" %% "play" % "2.7.0" % "provided",
     "com.typesafe.play" %% "play-ws" % "2.7.0" % "provided",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.7
+sbt.version=1.7.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.13")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.1"
+ThisBuild / version := "2.0.2-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version  := "2.0.1-SNAPSHOT"
+ThisBuild / version := "2.0.1"


### PR DESCRIPTION
More closely aligns with our docs and other releasable artifacts

See discussion in the internal "Maven Central and Sonatype" googledoc, and examples in https://github.com/guardian/pan-domain-authentication/blob/main/build.sbt

Also closes #15 

## What does this change?

Change build.sbt to combine sbt-release with sbt-sonatype for release process. Deduplicate some of the common settings between the play 2.7 and 2.8 artifacts.

## How to test

~If it looks good to you, pair with me to try a release?~

v2.0.1 successfully released from this branch

## How can we measure success?

Releasing this lib works in a more similar way to our other libs.

## Have we considered potential risks?

This is my first time setting up a lib for release; I may not know what I'm doing.