### PR TITLE
Support multiple secrets for secret rotation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: compile-test
+
+on:
+  workflow_dispatch:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Java 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+      - run: sbt test

--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,7 @@ lazy val `play27project` = (project in file("play")).settings(commonSettings).se
   libraryDependencies ++= Seq(
     "com.typesafe.play" %% "play" % "2.7.0" % "provided",
     "com.typesafe.play" %% "play-ws" % "2.7.0" % "provided",
-    "com.gu" %% "hmac-headers" % "2.0.0-SNAPSHOT",
+    "com.gu" %% "hmac-headers" % "2.0.0",
     "com.gu" %% "pan-domain-auth-play_2-7" % "1.2.0",
     "org.scalatest" %% "scalatest" % "3.2.10" % "test"
   ),

--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,7 @@ lazy val `play28project` = (project in file("play")).settings(commonSettings).se
   libraryDependencies ++= Seq(
     "com.typesafe.play" %% "play" % "2.8.11" % "provided",
     "com.typesafe.play" %% "play-ws" % "2.8.11" % "provided",
-    "com.gu" %% "hmac-headers" % "2.0.0-SNAPSHOT",
+    "com.gu" %% "hmac-headers" % "2.0.0",
     "com.gu" %% "pan-domain-auth-play_2-8" % "1.2.0",
     "org.scalatest" %% "scalatest" % "3.2.10" % "test"
   ),

--- a/build.sbt
+++ b/build.sbt
@@ -59,8 +59,9 @@ lazy val `play28project` = (project in file("play")).settings(commonSettings).se
   libraryDependencies ++= Seq(
     "com.typesafe.play" %% "play" % "2.8.11" % "provided",
     "com.typesafe.play" %% "play-ws" % "2.8.11" % "provided",
-    "com.gu" %% "hmac-headers" % "1.2.0",
-    "com.gu" %% "pan-domain-auth-play_2-8" % "1.2.0"
+    "com.gu" %% "hmac-headers" % "2.0.0-SNAPSHOT",
+    "com.gu" %% "pan-domain-auth-play_2-8" % "1.2.0",
+    "org.scalatest" %% "scalatest" % "3.2.10" % "test"
   ),
 )
 
@@ -72,8 +73,9 @@ lazy val `play27project` = (project in file("play")).settings(commonSettings).se
   libraryDependencies ++= Seq(
     "com.typesafe.play" %% "play" % "2.7.0" % "provided",
     "com.typesafe.play" %% "play-ws" % "2.7.0" % "provided",
-    "com.gu" %% "hmac-headers" % "1.2.0",
-    "com.gu" %% "pan-domain-auth-play_2-7" % "1.2.0"
+    "com.gu" %% "hmac-headers" % "2.0.0-SNAPSHOT",
+    "com.gu" %% "pan-domain-auth-play_2-7" % "1.2.0",
+    "org.scalatest" %% "scalatest" % "3.2.10" % "test"
   ),
 )
 

--- a/play/src/main/scala/com/gu/pandahmac/HmacAuthActions.scala
+++ b/play/src/main/scala/com/gu/pandahmac/HmacAuthActions.scala
@@ -1,7 +1,8 @@
 package com.gu.pandahmac
-import com.gu.hmac.HMACHeaders
+import com.gu.hmac.{HMACHeaders, ValidateHMACHeader}
 import com.gu.pandomainauth.action.{AuthActions, UserRequest}
 import com.gu.pandomainauth.model.User
+import org.slf4j.LoggerFactory
 import play.api.libs.ws.WSClient
 import play.api.mvc.Results._
 import play.api.mvc._
@@ -17,8 +18,7 @@ object HMACHeaderNames {
   val serviceNameKey = "X-Gu-Tools-Service-Name"
 }
 
-
-trait HMACAuthActions extends AuthActions with HMACHeaders {
+trait HMACAuthActions extends AuthActions with HMACSecrets {
   /**
     * Play application
     * Play application components that you must provide in order to use AuthActions
@@ -45,7 +45,6 @@ trait HMACAuthActions extends AuthActions with HMACHeaders {
       }
       case _ => if(useApiAuth) apiAuthByPanda(request, block) else authByPanda(request, block)
     }
-
   }
 
   type RequestHandler[A] = UserRequest[A] => Future[Result]

--- a/play/src/main/scala/com/gu/pandahmac/HmacSecrets.scala
+++ b/play/src/main/scala/com/gu/pandahmac/HmacSecrets.scala
@@ -9,20 +9,13 @@ trait HMACSecrets extends ValidateHMACHeader {
   def secret: String = ""
   def secretKeys: List[String] = List.empty
 
-  protected def gatherSecrets = {
-    val gatheredSecrets = (secret, secretKeys) match {
-      case ("", emptyList) if emptyList.isEmpty => List.empty
-      case (nonEmptySecret, _) if !nonEmptySecret.isEmpty => List(nonEmptySecret)
-      case ("", nonEmptyList) => nonEmptyList
-    }
-
-    if (gatheredSecrets.isEmpty) {
-      throw new Exception("Please set either 'secret' or 'secretKeys', no secret available for HMACAuthActions!")
-    }
-
-    gatheredSecrets
-  }
-
+  protected def gatherSecrets: List[String] =
+    if(!secretKeys.isEmpty) secretKeys
+    else if(!secret.isEmpty) List(secret)
+    else throw new Exception(
+      "Please set either 'secret' or 'secretKeys', no secret available for HMACAuthActions!"
+    )
+  
   def validateHMACHeaders(date: String, hmac: String, uri: URI): Boolean =
     gatherSecrets.exists(validateHMACHeadersWithSecret(_, date, hmac, uri))
 }

--- a/play/src/main/scala/com/gu/pandahmac/HmacSecrets.scala
+++ b/play/src/main/scala/com/gu/pandahmac/HmacSecrets.scala
@@ -1,0 +1,28 @@
+package com.gu.pandahmac
+
+import com.gu.hmac.ValidateHMACHeader
+
+import java.net.URI
+
+trait HMACSecrets extends ValidateHMACHeader {
+  @deprecated("In an upcoming release consumers will expected to provide a list of secrets to `secretKeys` to allow for secret rotation.")
+  def secret: String = ""
+  def secretKeys: List[String] = List.empty
+
+  protected def gatherSecrets = {
+    val gatheredSecrets = (secret, secretKeys) match {
+      case ("", emptyList) if emptyList.isEmpty => List.empty
+      case (nonEmptySecret, _) if !nonEmptySecret.isEmpty => List(nonEmptySecret)
+      case ("", nonEmptyList) => nonEmptyList
+    }
+
+    if (gatheredSecrets.isEmpty) {
+      throw new Exception("Please set either 'secret' or 'secretKeys', no secret available for HMACAuthActions!")
+    }
+
+    gatheredSecrets
+  }
+
+  def validateHMACHeaders(date: String, hmac: String, uri: URI): Boolean =
+    gatherSecrets.exists(validateHMACHeadersWithSecret(_, date, hmac, uri))
+}

--- a/play/src/test/scala/com/gu/pandahmac/HmacSecretsTest.scala
+++ b/play/src/test/scala/com/gu/pandahmac/HmacSecretsTest.scala
@@ -45,6 +45,16 @@ class HMACHeadersTest extends AnyWordSpec with Matchers {
 
         hmacSecrets.validateHMACHeaders(dateHeaderValue, s"HMAC $expectedHMAC", uri) should be(true)
       }
+
+      "preferentially use secretKeys over secret if both are provided" in {
+        val hmacSecrets = new HMACSecrets {
+          override val secret = "invalid"
+          override val secretKeys = List("invalid", validSecret, "invalid")
+          override val clock: Clock = fixedClock
+        }
+
+        hmacSecrets.validateHMACHeaders(dateHeaderValue, s"HMAC $expectedHMAC", uri) should be(true)
+      }
     }
   }
 }

--- a/play/src/test/scala/com/gu/pandahmac/HmacSecretsTest.scala
+++ b/play/src/test/scala/com/gu/pandahmac/HmacSecretsTest.scala
@@ -1,0 +1,50 @@
+package com.gu.pandahmac
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.net.URI
+import java.time.format.DateTimeFormatter
+import java.time.{Clock, Instant, ZoneId}
+
+class HMACHeadersTest extends AnyWordSpec with Matchers {
+
+  val uri = new URI("http:///www.theguardian.com/signin?query=someData")
+  val validSecret = "secret"
+  val expectedHMAC = "3AQ08uT4ToOISOXWMr68UvzrgrqIx3KK/pKEenwVES8="
+  val dateHeaderValue = "Tue, 15 Nov 1994 08:12:00 GMT"
+  val someTimeInThePast = Instant.from(DateTimeFormatter.RFC_1123_DATE_TIME.parse(dateHeaderValue))
+
+  val fixedClock =
+    Clock.fixed(someTimeInThePast, ZoneId.systemDefault)
+
+  "HMACSecrets" when {
+    "validateHMACHeaders" should {
+      "throw an exception if called without secret or secretKeys set" in {
+        val hmacSecrets = new HMACSecrets {}
+
+        intercept[Exception] {
+          hmacSecrets.validateHMACHeaders(dateHeaderValue, s"HMAC $expectedHMAC", uri)
+        }
+      }
+
+      "return true if a valid secret is set" in {
+        val hmacSecrets = new HMACSecrets {
+          override val secret = validSecret
+          override val clock: Clock = fixedClock
+        }
+
+        hmacSecrets.validateHMACHeaders(dateHeaderValue, s"HMAC $expectedHMAC", uri) should be(true)
+      }
+
+      "return true if any valid secret is in secretKeys" in {
+        val hmacSecrets = new HMACSecrets {
+          override val secretKeys = List("invalid", validSecret, "invalid")
+          override val clock: Clock = fixedClock
+        }
+
+        hmacSecrets.validateHMACHeaders(dateHeaderValue, s"HMAC $expectedHMAC", uri) should be(true)
+      }
+    }
+  }
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.1.1-SNAPSHOT"
+ThisBuild / version := "2.2.0-SNAPSHOT"


### PR DESCRIPTION
## What does this change?

This change builds on https://github.com/guardian/hmac-headers/pull/20 to support passing a list of secrets to check for validity. The intention is to allow for safe secret rotation as described in https://github.com/guardian/birthdays/pull/180

We attempt to make this a "soft" change and continue to support the existing interface, but add a deprecation notice for consumers warning it's going to change soon.

See https://github.com/guardian/birthdays/pull/183 for an example of downstream use.

Depends: https://github.com/guardian/hmac-headers/pull/20

## How to test

Run `sbt test`

> **Note**
> Tests run by the added GitHub action workflow will fail until the upstream changes have been released.

## How can we measure success?

Consumers are able to support secret rotation more easily in their projects.

## Have we considered potential risks?

Changing authentication code has the potential to disrupt consuming services if an interface changes, we attempt to keep it the same here.