### PR TITLE
Add instructions for testing HMAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,31 +16,31 @@ libraryDependencies += "com.gu" %% "panda-hmac-play_2.8" % "2.0.0"
 ```
 
 #### controller
-```
+```scala
 import com.gu.pandahmac.HMACAuthActions
-.
-.
-.
-@Singleton
-class MyController @Inject()(override val config:Configuration,
-                                  override val controllerComponents:ControllerComponents,
-                                  override val wsClient:WSClient,
-                                  override val refresher:InjectableRefresher)
-  extends AbstractController(controllerComponents) with PanDomainAuthActions with HMACAuthActions {
-  
-  override def secret = "mysecret" //or more likely, config.get[String]("application.hmacSecret")
 
-  def myApiActionWithBody = APIHMACAuthAction.async(circe.json(2048)) { request=>
-  .
-  .
-  .
+// ...
+
+@Singleton
+class MyController @Inject() (
+    override val config: Configuration,
+    override val controllerComponents: ControllerComponents,
+    override val wsClient: WSClient,
+    override val refresher: InjectableRefresher
+) extends AbstractController(controllerComponents)
+    with PanDomainAuthActions
+    with HMACAuthActions {
+
+  override def secretKeys = List("currentSecret") // You're likely to get your secret from configuration or a cloud service like AWS Secrets Manager
+
+  def myApiActionWithBody = APIHMACAuthAction.async(circe.json(2048)) { request => 
+    // ... do something with the request
   }
-  
-  def myRegularAction = HMACAuthAction {
-  }
-  
-  def myRegularAsyncAction = HMACAuthAction.async {
-  }
+
+  def myRegularAction = HMACAuthAction {}
+
+  def myRegularAsyncAction = HMACAuthAction.async {}
+}
 ```
 
 ## How to setup a machine client
@@ -59,3 +59,33 @@ seperated by a literal newline (unix-style, not CRLF)
  space and the digest, like this: `X-Gu-Tools-HMAC-Token: HMAC boXSTNumKWRX3eQk/BBeHYk`
 6. Send the request and the server should respond with a success.
 7. The default allowable clock skew is 5 minutes, if you have problems then this is the first thing to check.
+
+## Testing HMAC-authenticated endpoints in isolation
+
+[Postman]([url](https://www.postman.com/)) is a common environment for testing HTTP requests. We can add a [pre-request script]([url](https://learning.postman.com/docs/writing-scripts/pre-request-scripts/)) that automatically adds HMAC headers when we hit send.
+
+<details>
+<summary>Pre-request script</summary>
+  
+```js
+const URL = require("url");
+
+const uri = pm.request.url.toString();
+const secret = "Secret goes here :)";
+
+const httpDate = new Date().toUTCString();
+const path = new URL.parse(uri).path;
+const stringToSign = `${httpDate}\n${path}`;
+const stringToSignBytes = CryptoJS.enc.Utf8.parse(stringToSign);
+const secretBytes = CryptoJS.enc.Utf8.parse(secret);
+
+const signature = CryptoJS.enc.Base64.stringify(CryptoJS.HmacSHA256(stringToSignBytes, secretBytes));
+const authToken = `HMAC ${signature}`;
+
+pm.request.headers.add({ key: 'X-Gu-Tools-HMAC-Date', value: httpDate });
+pm.request.headers.add({ key: 'X-Gu-Tools-HMAC-Token', value: authToken });
+```
+
+</details>
+
+


### PR DESCRIPTION
## What does this change?

It's not straightforward to test a HMAC-authed endpoint. This PR adds a pre-request script that makes testing from Postman trivial.

It also updates the Scala example, as we maintain a list of secrets to enable key rotation as of #20. 

## How to test

All make sense? Anything to add? We could add your [python script](https://gist.github.com/kenoir/1a8ba8f970b36d5f0dd9e646f222153c), too, @kenoir! 