### PR TITLE
add note explaining repo deprecation and redirecting future travellers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 > [!WARNING]  
-> The panda-hmac modules have been moved to guardian/pan-domain-authentication. This repo is now out of date.
+> The panda-hmac modules have been moved to [guardian/pan-domain-authentication](https://github.com/guardian/pan-domain-authentication). This repo is now out of date.
 
 # Play HMAC
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!WARNING]  
+> The panda-hmac modules have been moved to guardian/pan-domain-authentication. This repo is now out of date.
+
 # Play HMAC
 
 Some useful `AuthActions` for working with machine/user auth based of HMAC for the robots and cookies for the monkeys.


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

this repo's contents are now in guardian/pan-domain-authentication, so this repo should be archived. Leave a note for future travellers


